### PR TITLE
ci: add build test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Test
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: mlugg/setup-zig@a67e68dc5c8281d9608136d3d7ca1b282213e4ac # v1.2.1
+      - run: zig build test


### PR DESCRIPTION
Add a simple Github Action to run `zig build test` on `main` and pull requests. Example run available on my fork: https://github.com/thevilledev/ziglang-set/actions/runs/12194745267

Relates to #4 