### PR TITLE
refactor(array_hash_set): streamline set operations and fix containsAll

### DIFF
--- a/src/array_hash_set/unmanaged.zig
+++ b/src/array_hash_set/unmanaged.zig
@@ -146,7 +146,7 @@ pub fn ArraySetUnmanaged(comptime E: type) type {
         pub fn containsAll(self: Self, other: Self) bool {
             var iter = other.iterator();
             while (iter.next()) |el| {
-                if (!self.unmanaged.contains(el.*)) {
+                if (!self.unmanaged.contains(el.key_ptr.*)) {
                     return false;
                 }
             }


### PR DESCRIPTION
- Reimplement managed set operations using unmanaged counterparts
- Fix incorrect element check in unmanaged.containsAll
- Add benchmark tests for common operations
- Simplify cloneWithAllocator implementation

The `containsAll` bugfix was needed because the unmanaged version's iterator returns Entry pointers (key/value pairs), but was checking for the Entry itself rather than the entry's key. The corrected line properly accesses the key via `el.key_ptr.*`.

Benchmark output:

```bash
$ zig test src/array_hash_set/managed.zig -O ReleaseFast --test-filter "benchmark"
unionOf: 24185 ops/sec (41346.33 ns/op)
intersectionOf: 18515 ops/sec (54007.93 ns/op)
containsAll: 367996 ops/sec (2717.42 ns/op)
All 1 tests passed.
```
