### PR TITLE
Feature: isDisjoint function across all four versions of the Set implementations including unit-tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This implementation gives credit and acknowledgement to the [Zig language](https
     * union, unionUpdate (in-place variant)
     * difference, differenceUpdate (in-place variant)
     * symmetricDifference, symmetricDifferenceUpdate (in-place variant)
+    * isDisjoint
     * isSubset
     * isSuperset
     * isProperSubset

--- a/src/array_hash_set/managed.zig
+++ b/src/array_hash_set/managed.zig
@@ -289,6 +289,12 @@ pub fn ArraySetManaged(comptime E: type) type {
             self.unmanaged = interSet.unmanaged;
         }
 
+        /// isDisjoint returns true if the intersection between two sets is the null set.
+        /// Otherwise returns false.
+        pub fn isDisjoint(self: Self, other: Self) bool {
+            return self.unmanaged.isDisjoint(other.unmanaged);
+        }
+
         /// In place style:
         /// differenceOfUpdate
         /// symmetric_differenceOf_update
@@ -573,6 +579,28 @@ test "comprehensive usage" {
     // subsetOf
 
     // supersetOf
+}
+
+test "isDisjoint" {
+    var a = ArraySetManaged(u32).init(std.testing.allocator);
+    defer a.deinit();
+    _ = try a.appendSlice(&.{ 20, 30, 40 });
+
+    var b = ArraySetManaged(u32).init(std.testing.allocator);
+    defer b.deinit();
+    _ = try b.appendSlice(&.{ 202, 303, 403 });
+
+    // Test the true case.
+    try expect(a.isDisjoint(b));
+    try expect(b.isDisjoint(a));
+
+    // Test the false case.
+    var c = ArraySetManaged(u32).init(std.testing.allocator);
+    defer c.deinit();
+    _ = try c.appendSlice(&.{ 20, 30, 400 });
+
+    try expect(!a.isDisjoint(c));
+    try expect(!c.isDisjoint(a));
 }
 
 test "clear/capacity" {

--- a/src/hash_set/managed.zig
+++ b/src/hash_set/managed.zig
@@ -347,6 +347,12 @@ pub fn HashSetManagedWithContext(comptime E: type, comptime Context: type, compt
             self.map = interSet.map;
         }
 
+        /// isDisjoint returns true if the intersection between two sets is the null set.
+        /// Otherwise returns false.
+        pub fn isDisjoint(self: Self, other: Self) bool {
+            return self.map.isDisjoint(other.map);
+        }
+
         /// In place style:
         /// differenceOfUpdate
         /// symmetric_differenceOf_update
@@ -657,6 +663,28 @@ test "comprehensive usage" {
     // subsetOf
 
     // supersetOf
+}
+
+test "isDisjoint" {
+    var a = HashSetManaged(u32).init(std.testing.allocator);
+    defer a.deinit();
+    _ = try a.appendSlice(&.{ 20, 30, 40 });
+
+    var b = HashSetManaged(u32).init(std.testing.allocator);
+    defer b.deinit();
+    _ = try b.appendSlice(&.{ 202, 303, 403 });
+
+    // Test the true case.
+    try expect(a.isDisjoint(b));
+    try expect(b.isDisjoint(a));
+
+    // Test the false case.
+    var c = HashSetManaged(u32).init(std.testing.allocator);
+    defer c.deinit();
+    _ = try c.appendSlice(&.{ 20, 30, 400 });
+
+    try expect(!a.isDisjoint(c));
+    try expect(!c.isDisjoint(a));
 }
 
 test "clear/capacity" {

--- a/src/hash_set/unmanaged.zig
+++ b/src/hash_set/unmanaged.zig
@@ -351,6 +351,22 @@ pub fn HashSetUnmanagedWithContext(comptime E: type, comptime Context: type, com
             self.unmanaged = interSet.unmanaged;
         }
 
+        /// isDisjoint returns true if the intersection between two sets is the null set.
+        /// Otherwise returns false.
+        pub fn isDisjoint(self: Self, other: Self) bool {
+            // Optimization: Find the smaller of the two, and iterate over the smaller set
+            const smaller = if (self.cardinality() <= other.cardinality()) self else other;
+            const larger = if (self.cardinality() <= other.cardinality()) other else self;
+
+            var iter = smaller.iterator();
+            while (iter.next()) |el| {
+                if (larger.contains(el.*)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         pub fn isEmpty(self: Self) bool {
             return self.unmanaged.count() == 0;
         }
@@ -656,6 +672,28 @@ test "comprehensive usage" {
     // subsetOf
 
     // supersetOf
+}
+
+test "isDisjoint" {
+    var a = HashSetUnmanaged(u32).init();
+    defer a.deinit(testing.allocator);
+    _ = try a.appendSlice(testing.allocator, &.{ 20, 30, 40 });
+
+    var b = HashSetUnmanaged(u32).init();
+    defer b.deinit(testing.allocator);
+    _ = try b.appendSlice(testing.allocator, &.{ 202, 303, 403 });
+
+    // Test the true case.
+    try expect(a.isDisjoint(b));
+    try expect(b.isDisjoint(a));
+
+    // Test the false case.
+    var c = HashSetUnmanaged(u32).init();
+    defer c.deinit(testing.allocator);
+    _ = try c.appendSlice(testing.allocator, &.{ 20, 30, 400 });
+
+    try expect(!a.isDisjoint(c));
+    try expect(!c.isDisjoint(a));
 }
 
 test "clone" {


### PR DESCRIPTION
- Adds `isDisjoint` with no allocations needed. A Set is said to be disjoint against another Set if the intersection between the two is null.
- Optimization: Find the smaller of the two sets, and iterate only that one.
- Updated README.md
- Updated Docs
- Added unit-tests as well.