### PR TITLE
build: latest nightly changed the type

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = .ziglangSet,
+    .name = "ziglangSet",
     .version = "0.0.1",
     .fingerprint = 0x65aa5acd2ef4855,
     .minimum_zig_version = "0.14.0",


### PR DESCRIPTION
tested on zig version: `0.14.0-dev.3086+b3c63e5de`