### PR TITLE
chore(deps): bump to checkout action v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Test
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
       - uses: mlugg/setup-zig@v2
       - run: zig build test


### PR DESCRIPTION
Bump to latest available version. Also, disable credential persistence and use a shallow clone as we don't need the full history.